### PR TITLE
Fix "not" snippet

### DIFF
--- a/snippets/haskell-unicode.cson
+++ b/snippets/haskell-unicode.cson
@@ -49,7 +49,7 @@
     'body': '∧'
   "Unicode 'not'":
     'prefix': 'not'
-    'body': '(⌐)'
+    'body': '(¬)'
   "Unicode '==' (equal)":
     'prefix': '=='
     'body': '≡'


### PR DESCRIPTION
The snippet previously produced (⌐), however Prelude.Unicode (from base-unicode-symbols) uses (¬).
